### PR TITLE
Support CTEs in RangeVar

### DIFF
--- a/test/expected/unqualified_cte.out
+++ b/test/expected/unqualified_cte.out
@@ -1,0 +1,3 @@
+Unqualified object reference: foo
+
+Errors: 0 Warnings: 1 Unknown: 0

--- a/test/sql/unqualified_cte.sql
+++ b/test/sql/unqualified_cte.sql
@@ -1,0 +1,13 @@
+WITH cte1 AS (
+    VALUES (1)
+), cte2 AS (
+    WITH foo AS (
+        SELECT * FROM cte1
+    )
+    SELECT * FROM foo
+), cte3 AS (
+    SELECT * FROM foo -- This will warn, foo is not a previously defined CTE
+)
+SELECT * FROM cte1 AS c1
+    CROSS JOIN cte2
+    CROSS JOIN cte3;


### PR DESCRIPTION
Without this change a CTE referenced from a RangeVar would warn with
'Unqualified object reference', e.g.

```
> ./pgspot <<<"WITH cte1 AS (VALUES (1)) SELECT * FROM cte1";

Unqualified object reference: cte1

Errors: 0 Warnings: 1 Unknown: 0
```