### PR TITLE
Allow CREATE OR REPLACE and CREATE IF NOT EXISTS in created schemas

### DIFF
--- a/test/expected/created_schema.out
+++ b/test/expected/created_schema.out
@@ -1,0 +1,2 @@
+
+Errors: 0 Warnings: 0 Unknown: 0

--- a/test/sql/created_schema.sql
+++ b/test/sql/created_schema.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA test_schema;
+
+CREATE COLLATION IF NOT EXISTS test_schema.collation3 (locale = 'fr_FR.utf8');
+CREATE FOREIGN TABLE IF NOT EXISTS test_schema.unsafe_table4(c4444 text) SERVER server4;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_schema.matview6 AS SELECT pg_catalog.now();
+CREATE SEQUENCE IF NOT EXISTS test_schema.sequence8;
+CREATE TABLE IF NOT EXISTS test_schema.table10(c10 text);
+CREATE TABLE IF NOT EXISTS test_schema.table11 AS SELECT pg_catalog.now();


### PR DESCRIPTION
If we created the schema, then we can assume that:

1. We are the owner of the schema
2. No non-superusers would have been able to pre-create objects