### PR TITLE
Check function calls in the FROM position

### DIFF
--- a/test/expected/range_function.out
+++ b/test/expected/range_function.out
@@ -1,0 +1,4 @@
+PS016: Unqualified function call: unsafe_call1
+PS016: Unqualified function call: unsafe_call2
+
+Errors: 0 Warnings: 2 Unknown: 0

--- a/test/sql/range_function.sql
+++ b/test/sql/range_function.sql
@@ -1,0 +1,2 @@
+SELECT * FROM pg_catalog.safe_call1(unsafe_call1());
+SELECT * FROM ROWS FROM (pg_catalog.safe_call2(), unsafe_call2());

--- a/visitors.py
+++ b/visitors.py
@@ -227,6 +227,19 @@ class SQLVisitor(Visitor):
     if not node.schemaname and node.relname not in cte_names and not self.state.searchpath_secure:
       self.state.warn("PS017", "{}".format(node.relname))
 
+  def visit_RangeFunction(self, ancestors, node):
+    # Postgres has the following to say about RangeFunction:
+    # > RangeFunction - function call appearing in a FROM clause
+    # >
+    # > functions is a List because we use this to represent the construct
+    # > ROWS FROM(func1(...), func2(...), ...).  Each element of this list is a
+    # > two-element sublist, the first element being the untransformed function
+    # > call tree, and the second element being a possibly-empty list of ColumnDef
+    # > nodes representing any columndef list attached to that function within the
+    # > ROWS FROM() syntax.
+    for function in node.functions:
+      self(function[0])
+
   def extract_cte_names(self, ancestor):
     # Iterate through parents, obtaining the names of CTEs which were directly defined
     cte_names = set()


### PR DESCRIPTION
A function call placed in the FROM position of a SELECT statement (e.g.
`SELECT * FROM function_call();` parses to a RangeFunction AST node,
which was not being handled. We need to visit all functions in the
function list of the node.