### PR TITLE
Allow specifying "sql accepting" functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ vulnerabilities which pgspot detects, and their potential mitigations.
 
 ```
 > ./pgspot -h
-usage: pgspot [-h] [-a] [--proc-without-search-path PROC] [--summary-only] [--plpgsql | --no-plpgsql] [--explain EXPLAIN] [--ignore IGNORE] [FILE ...]
+usage: pgspot [-h] [-a] [--proc-without-search-path PROC] [--summary-only] [--plpgsql | --no-plpgsql] [--explain EXPLAIN] [--ignore IGNORE] [--sql-accepting SQL_FN] [FILE ...]
 
 Spot vulnerabilities in PostgreSQL SQL scripts
 
@@ -42,8 +42,8 @@ options:
                         Analyze PLpgSQL code (default: True)
   --explain EXPLAIN     Describe an error/warning code
   --ignore IGNORE       Ignore error or warning code
-```
-
+  --sql-accepting SQL_FN
+                        Specify one or more sql-accepting functions
 ```
 > ./pgspot --ignore PS017 <<<"CREATE TABLE IF NOT EXISTS foo();"
 PS012: Unsafe table creation: foo
@@ -51,3 +51,14 @@ PS012: Unsafe table creation: foo
 Errors: 1 Warnings: 0 Unknown: 0
 ```
 
+#### SQL-accepting functions
+
+It is a common pattern that SQL-accepting functions exist, which take a
+string-like argument which will be executed as SQL. This can "hide" some SQL
+from pgspot, as the string-like argument masks the SQL. With the
+`--sql-accepting` argument, pgspot can be told about such functions.
+
+Assuming a function named `execute_sql` which takes a SQL string as its first
+argument, and executes it. With `pgspot --sql-accepting=execute_sql` we can
+tell pgspot `execute_sql` may accept SQL. pgspot will attempt to unpack and
+evaluate all arguments to that function as SQL.

--- a/pgspot
+++ b/pgspot
@@ -7,6 +7,7 @@ from codes import codes
 from textwrap import dedent
 import sys
 
+
 parser = ArgumentParser(description='Spot vulnerabilities in PostgreSQL SQL scripts')
 parser.add_argument("-a","--append",dest="append",action="store_true",default=False,help="append files before checking")
 parser.add_argument("--proc-without-search-path",metavar="PROC",dest="proc_without_search_path",action="append",default=list(),help="whitelist functions without explicit search_path")
@@ -14,6 +15,7 @@ parser.add_argument("--summary-only",dest="summary_only",action="store_true",def
 parser.add_argument("--plpgsql", action=BooleanOptionalAction, default=True, help="Analyze PLpgSQL code")
 parser.add_argument("--explain", dest="explain", default=None, help="Describe an error/warning code")
 parser.add_argument("--ignore", dest="ignore", action='append', default=list(), type=str, help="Ignore error or warning code")
+parser.add_argument("--sql-accepting", dest="sql_fn", action='append', default=list(), help="Specify one or more sql-accepting functions")
 parser.add_argument('files',metavar='FILE',type=str,nargs='*',help='file to check for vulnerabilities')
 
 args = parser.parse_args()

--- a/tests/sql_accepting_function_test.py
+++ b/tests/sql_accepting_function_test.py
@@ -1,0 +1,41 @@
+from util import run
+
+
+def test_call_sql_accepting_function():
+    sql = """
+    CALL some_schema.execute_sql($ee$
+      DO $DO$
+      BEGIN
+        SELECT unsafe_call();
+      END $DO$;
+    $ee$);
+    """
+    args = ["--sql-accepting=execute_sql"]
+    output = run(sql, args)
+
+    assert "PS016" in output
+
+
+def test_select_sql_accepting_function():
+    sql = """
+    SELECT some_schema.execute_sql($ee$
+      DO $DO$
+      BEGIN
+        SELECT unsafe_call();
+      END $DO$;
+    $ee$);
+    """
+    args = ["--sql-accepting=execute_sql"]
+    output = run(sql, args)
+
+    assert "PS016" in output
+
+
+def test_select_sql_accepting_function_with_non_sql():
+    sql = """
+    SELECT some_schema.execute_sql(some_parameter);
+    """
+    args = ["--sql-accepting=execute_sql"]
+    output = run(sql, args)
+
+    assert "Errors: 0 Warnings: 0" in output

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,8 @@
+import subprocess
+
+
+def run(sql, args):
+    return subprocess.run(["echo '{}' | python pgspot {}".format(sql, " ".join(args))]
+                          , shell=True
+                          , capture_output=True
+                          , text=True).stdout


### PR DESCRIPTION
Some complex scripts may use functions which themselves execute SQL
which is provided as a string-like argument. With the --sql-accepting
argument, pgspot can be told about these functions, and will attempt to
inspect the string-like argument as SQL.