### PR TITLE
Do not emit PS008

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -176,7 +176,7 @@ TODO
 TODO
 
 ## PS008: Unqualified alter sequence
-TODO
+NOTE: This warning is not produced. 
 
 ## PS009: Unsafe CASE expression
 A "simple" `CASE` expression was used without a secure search_path.

--- a/codes.py
+++ b/codes.py
@@ -195,7 +195,7 @@ codes = {
     'PS008': {
         'title': "Unqualified alter sequence",
         'description': """
-        TODO
+        NOTE: This warning is not produced. 
         """
     },
     'PS009': {

--- a/visitors.py
+++ b/visitors.py
@@ -158,12 +158,6 @@ class SQLVisitor(Visitor):
       if node.kind == VariableSetKind.VAR_RESET:
         self.state.reset_searchpath()
 
-  def visit_AlterSeqStmt(self, ancestors, node):
-    # This is not really a problem inside extension scripts since search_path
-    # will be set to determined value but it might be inside function bodies.
-    if not node.sequence.schemaname and not self.state.searchpath_secure:
-      self.state.warn("PS008", "{}".format(node.sequence.relname))
-
   def visit_CaseExpr(self, ancestors, node):
     if node.arg and not self.state.searchpath_secure:
       self.state.error("PS009", "{}".format(raw_sql(node)))


### PR DESCRIPTION
It turns out that PS008 is effectively a duplicate of PS017. Before this
change we would emit the following:

```
./pgspot <<<'ALTER SEQUENCE foo_sequence START WITH 1000;'
PS008: Unqualified alter sequence: foo_sequence
PS017: Unqualified object reference: foo_sequence

Errors: 0 Warnings: 2 Unknown: 0
```