### PR TITLE
Track aggregate creation

### DIFF
--- a/formatters.py
+++ b/formatters.py
@@ -33,3 +33,20 @@ def format_function(node):
     else:
         args = ""
     return "{}({})".format(format_name(node.funcname), args)
+
+
+def format_aggregate(node):
+    if node.oldstyle:
+        basetype = [b.arg.names for b in node.definition if b.defname == "basetype"]
+        if basetype:
+            basetype = basetype[0]
+
+        if not basetype:
+            args = ""
+        elif len(basetype) == 2 and basetype[0].val == "pg_catalog":
+            args = basetype[1].val
+        else:
+            args = ",".join([s.val for s in basetype])
+    else:
+        args = ",".join([raw_sql(arg.argType) for arg in node.args[0]])
+    return "{}({})".format(format_name(node.defnames), args)

--- a/state.py
+++ b/state.py
@@ -9,9 +9,6 @@ class Counter:
         self.unknowns = 0
         self.errors = 0
 
-        self.created_schemas = list()
-        self.created_functions = list()
-
     def warn(self, code, context):
         if code not in self.args.ignore:
             self.warnings += 1
@@ -47,6 +44,7 @@ class State:
         self.counter = counter
         self.args = counter.args
         self.created_schemas = list()
+        self.created_aggregates = list()
         self.created_functions = list()
         self.searchpath_secure = False
         self.searchpath_local = False

--- a/testdata/aggregate_tracking.sql
+++ b/testdata/aggregate_tracking.sql
@@ -1,0 +1,26 @@
+
+-- should warn twice
+CREATE OR REPLACE AGGREGATE s1.agg3(int) (sfunc=abc);
+CREATE OR REPLACE AGGREGATE s1.agg3(int) (sfunc=abc);
+
+CREATE AGGREGATE s1.agg6(int) (sfunc=abc);
+-- should not warn since it was previously created in this script
+CREATE OR REPLACE AGGREGATE s1.agg6(int) (sfunc=abc);
+-- different schema should warn
+CREATE OR REPLACE AGGREGATE s2.agg6(int) (sfunc=abc);
+-- should warn because no schema
+CREATE OR REPLACE AGGREGATE agg6(int) (sfunc=abc);
+
+-- different signature should warn
+CREATE OR REPLACE AGGREGATE s1.agg6(int,int) (sfunc=abc);
+
+-- old style
+CREATE AGGREGATE s3.agg14 (BASETYPE=int,SFUNC=int4and,STYPE=int);
+-- should not warn since it was previously created in this script
+CREATE OR REPLACE AGGREGATE s3.agg14 (BASETYPE=int,SFUNC=int4and,STYPE=int);
+-- should warn because of different basetype
+CREATE OR REPLACE AGGREGATE s3.agg14 (BASETYPE=int8,SFUNC=int4and,STYPE=int);
+
+-- new style with different signature should warn
+CREATE OR REPLACE AGGREGATE s3.agg14(int8) (SFUNC=int4and,STYPE=int);
+

--- a/testdata/expected/aggregate_tracking.out
+++ b/testdata/expected/aggregate_tracking.out
@@ -1,0 +1,10 @@
+PS007: Unsafe object creation: s1.agg3(integer)
+PS007: Unsafe object creation: s1.agg3(integer)
+PS007: Unsafe object creation: s2.agg6(integer)
+PS017: Unqualified object reference: agg6
+PS007: Unsafe object creation: agg6(integer)
+PS007: Unsafe object creation: s1.agg6(integer,integer)
+PS007: Unsafe object creation: s3.agg14(int8)
+PS007: Unsafe object creation: s3.agg14(int8)
+
+Errors: 7 Warnings: 1 Unknown: 0

--- a/testdata/expected/replace.out
+++ b/testdata/expected/replace.out
@@ -1,5 +1,5 @@
 PS017: Unqualified object reference: unsafe_agg3
-PS007: Unsafe object creation: unsafe_agg3
+PS007: Unsafe object creation: unsafe_agg3()
 PS002: Unsafe function creation: unsafe_func4()
 PS005: Function without explicit search_path: unsafe_func4()
 PS002: Unsafe function creation: unsafe_proc5()


### PR DESCRIPTION
To reduce false positives when an aggregate is initially created
with CREATE and later replaced by CREATE OR REPLACE change pgspot
to track aggregate creation when processing statements.