### PR TITLE
Add line numbers to output

### DIFF
--- a/pgspot
+++ b/pgspot
@@ -26,7 +26,7 @@ if args.files:
   if args.append:
     # treat all files as single unit during processing
     data = "\n".join([open(f).read() for f in args.files])
-    visit_sql(State(counter), data)
+    visit_sql(State(counter), data, toplevel=True)
 
   else:
     # process each file individually
@@ -35,7 +35,7 @@ if args.files:
         print("\n{}\n".format(f))
       data = open(f).read()
 
-      visit_sql(State(counter), data)
+      visit_sql(State(counter), data, toplevel=True)
 
 elif args.explain:
   code = args.explain
@@ -50,7 +50,7 @@ else:
   # read from stdin
   data = sys.stdin.read()
 
-  visit_sql(State(counter), data)
+  visit_sql(State(counter), data, toplevel=True)
 
 print(counter)
 

--- a/testdata/expected/aggregate_tracking.out
+++ b/testdata/expected/aggregate_tracking.out
@@ -1,10 +1,10 @@
-PS007: Unsafe object creation: s1.agg3(integer)
-PS007: Unsafe object creation: s1.agg3(integer)
-PS007: Unsafe object creation: s2.agg6(integer)
-PS017: Unqualified object reference: agg6
-PS007: Unsafe object creation: agg6(integer)
-PS007: Unsafe object creation: s1.agg6(integer,integer)
-PS007: Unsafe object creation: s3.agg14(int8)
-PS007: Unsafe object creation: s3.agg14(int8)
+PS007: Unsafe object creation: s1.agg3(integer) at line 2
+PS007: Unsafe object creation: s1.agg3(integer) at line 4
+PS007: Unsafe object creation: s2.agg6(integer) at line 9
+PS017: Unqualified object reference: agg6 at line 11
+PS007: Unsafe object creation: agg6(integer) at line 11
+PS007: Unsafe object creation: s1.agg6(integer,integer) at line 13
+PS007: Unsafe object creation: s3.agg14(int8) at line 21
+PS007: Unsafe object creation: s3.agg14(int8) at line 23
 
 Errors: 7 Warnings: 1 Unknown: 0

--- a/testdata/expected/cast.out
+++ b/testdata/expected/cast.out
@@ -1,6 +1,6 @@
-PS017: Unqualified object reference: custom_type in CAST(1 AS custom_type)
-PS017: Unqualified object reference: int4 in CAST('1' AS int4)
-PS017: Unqualified object reference: int4 in CAST('1' AS int4)
-PS017: Unqualified object reference: int4 in CAST('1' AS int4)
+PS017: Unqualified object reference: custom_type in CAST(1 AS custom_type) at line 6
+PS017: Unqualified object reference: int4 in CAST('1' AS int4) at line 12
+PS017: Unqualified object reference: int4 in CAST('1' AS int4) at line 15
+PS017: Unqualified object reference: int4 in CAST('1' AS int4) at line 18
 
 Errors: 4 Warnings: 0 Unknown: 0

--- a/testdata/expected/createfunc.out
+++ b/testdata/expected/createfunc.out
@@ -1,14 +1,14 @@
-PS002: Unsafe function creation: unsafe3()
-PS005: Function without explicit search_path: unsafe3()
-PS016: Unqualified function call: unsafe_call3
-PS005: Function without explicit search_path: safe5()
-PS016: Unqualified function call: unsafe_call5
-PS005: Function without explicit search_path: f8()
-PS016: Unqualified function call: unsafe_call8
-PS005: Function without explicit search_path: f8()
-PS002: Unsafe function creation: f8(integer)
-PS005: Function without explicit search_path: f8(integer)
-PS005: Function without explicit search_path: safe16()
-PS016: Unqualified function call: unsafe_call18
+PS002: Unsafe function creation: unsafe3() at line 2
+PS005: Function without explicit search_path: unsafe3() at line 2
+PS016: Unqualified function call: unsafe_call3 at line 2
+PS005: Function without explicit search_path: safe5() at line 4
+PS016: Unqualified function call: unsafe_call5 at line 4
+PS005: Function without explicit search_path: f8() at line 6
+PS016: Unqualified function call: unsafe_call8 at line 6
+PS005: Function without explicit search_path: f8() at line 9
+PS002: Unsafe function creation: f8(integer) at line 12
+PS005: Function without explicit search_path: f8(integer) at line 12
+PS005: Function without explicit search_path: safe16() at line 15
+PS016: Unqualified function call: unsafe_call18 at line 15
 
 Errors: 2 Warnings: 10 Unknown: 0

--- a/testdata/expected/do.out
+++ b/testdata/expected/do.out
@@ -1,7 +1,7 @@
-PS016: Unqualified function call: unsafe_call2
-PS016: Unqualified function call: unsafe_call3
-PS016: Unqualified function call: unsafe_call8
-PS016: Unqualified function call: unsafe_call10
-PS016: Unqualified function call: unsafe_call19
+PS016: Unqualified function call: unsafe_call2 at line 2
+PS016: Unqualified function call: unsafe_call3 at line 3
+PS016: Unqualified function call: unsafe_call8 at line 4
+PS016: Unqualified function call: unsafe_call10 at line 4
+PS016: Unqualified function call: unsafe_call19 at line 4
 
 Errors: 0 Warnings: 5 Unknown: 0

--- a/testdata/expected/exists.out
+++ b/testdata/expected/exists.out
@@ -1,18 +1,18 @@
-PS017: Unqualified object reference: collation3
-PS007: Unsafe object creation: collation3
-PS012: Unsafe table creation: unsafe_table4
-PS017: Unqualified object reference: unsafe_table4
-PS014: Unsafe index creation: index5
-PS017: Unqualified object reference: table5
-PS007: Unsafe object creation: matview6
-PS017: Unqualified object reference: matview6
-PS010: Unsafe schema creation: schema7
-PS011: Unsafe sequence creation: sequence8
-PS017: Unqualified object reference: sequence8
-PS013: Unsafe foreign server creation: server9
-PS012: Unsafe table creation: table10
-PS017: Unqualified object reference: table10
-PS007: Unsafe object creation: table11
-PS017: Unqualified object reference: table11
+PS017: Unqualified object reference: collation3 at line 1
+PS007: Unsafe object creation: collation3 at line 1
+PS012: Unsafe table creation: unsafe_table4 at line 4
+PS017: Unqualified object reference: unsafe_table4 at line 4
+PS014: Unsafe index creation: index5 at line 5
+PS017: Unqualified object reference: table5 at line 5
+PS007: Unsafe object creation: matview6 at line 6
+PS017: Unqualified object reference: matview6 at line 6
+PS010: Unsafe schema creation: schema7 at line 7
+PS011: Unsafe sequence creation: sequence8 at line 8
+PS017: Unqualified object reference: sequence8 at line 8
+PS013: Unsafe foreign server creation: server9 at line 9
+PS012: Unsafe table creation: table10 at line 10
+PS017: Unqualified object reference: table10 at line 10
+PS007: Unsafe object creation: table11 at line 11
+PS017: Unqualified object reference: table11 at line 11
 
 Errors: 9 Warnings: 7 Unknown: 0

--- a/testdata/expected/nested_searchpath.out
+++ b/testdata/expected/nested_searchpath.out
@@ -1,12 +1,12 @@
-PS016: Unqualified function call: unsafe_call2
-PS005: Function without explicit search_path: f10_no_path()
-PS016: Unqualified function call: unsafe_call10
-PS016: Unqualified function call: unsafe_call_in_do14
-PS005: Function without explicit search_path: f18_no_path()
-PS016: Unqualified function call: unsafe_call18
-PS005: Function without explicit search_path: f19_path()
-PS016: Unqualified function call: unsafe_call19
-PS005: Function without explicit search_path: f25_nested_no_path()
-PS016: Unqualified function call: unsafe_call25
+PS016: Unqualified function call: unsafe_call2 at line 2
+PS005: Function without explicit search_path: f10_no_path() at line 10
+PS016: Unqualified function call: unsafe_call10 at line 10
+PS016: Unqualified function call: unsafe_call_in_do14 at line 13
+PS005: Function without explicit search_path: f18_no_path() at line 18
+PS016: Unqualified function call: unsafe_call18 at line 18
+PS005: Function without explicit search_path: f19_path() at line 20
+PS016: Unqualified function call: unsafe_call19 at line 20
+PS005: Function without explicit search_path: f25_nested_no_path() at line 23
+PS016: Unqualified function call: unsafe_call25 at line 23
 
 Errors: 0 Warnings: 10 Unknown: 0

--- a/testdata/expected/operator.out
+++ b/testdata/expected/operator.out
@@ -1,3 +1,3 @@
-PS017: Unqualified object reference: #?
+PS017: Unqualified object reference: #? at line 2
 
 Errors: 0 Warnings: 1 Unknown: 0

--- a/testdata/expected/plpgsql_function.out
+++ b/testdata/expected/plpgsql_function.out
@@ -1,13 +1,13 @@
-PS005: Function without explicit search_path: plpgsqlfunc3()
-PS016: Unqualified function call: unsafe_call3
-PS005: Function without explicit search_path: plpgsqlfunc4()
-PS016: Unqualified function call: unsafe_call4
-PS005: Function without explicit search_path: plpgsqlfunc5()
-PS016: Unqualified function call: unsafe_call5
-PS005: Function without explicit search_path: plpgsqlfunc13()
-PS016: Unqualified function call: unsafe_call13
-PS005: Function without explicit search_path: plpgsqlfunc16()
-PS016: Unqualified function call: unsafe_call17
-PS016: Unqualified function call: unsafe_call21
+PS005: Function without explicit search_path: plpgsqlfunc3() at line 2
+PS016: Unqualified function call: unsafe_call3 at line 2
+PS005: Function without explicit search_path: plpgsqlfunc4() at line 4
+PS016: Unqualified function call: unsafe_call4 at line 4
+PS005: Function without explicit search_path: plpgsqlfunc5() at line 5
+PS016: Unqualified function call: unsafe_call5 at line 5
+PS005: Function without explicit search_path: plpgsqlfunc13() at line 13
+PS016: Unqualified function call: unsafe_call13 at line 13
+PS005: Function without explicit search_path: plpgsqlfunc16() at line 14
+PS016: Unqualified function call: unsafe_call17 at line 14
+PS016: Unqualified function call: unsafe_call21 at line 14
 
 Errors: 0 Warnings: 11 Unknown: 0

--- a/testdata/expected/ps009-simplified-case.out
+++ b/testdata/expected/ps009-simplified-case.out
@@ -1,3 +1,3 @@
-PS009: Unsafe CASE expression: CASE a OPERATOR(pg_catalog.=) b WHEN TRUE THEN 'true' WHEN FALSE THEN 'false' END
+PS009: Unsafe CASE expression: CASE a OPERATOR(pg_catalog.=) b WHEN TRUE THEN 'true' WHEN FALSE THEN 'false' END at line 1
 
 Errors: 1 Warnings: 0 Unknown: 0

--- a/testdata/expected/range_function.out
+++ b/testdata/expected/range_function.out
@@ -1,4 +1,4 @@
-PS016: Unqualified function call: unsafe_call1
-PS016: Unqualified function call: unsafe_call2
+PS016: Unqualified function call: unsafe_call1 at line 1
+PS016: Unqualified function call: unsafe_call2 at line 2
 
 Errors: 0 Warnings: 2 Unknown: 0

--- a/testdata/expected/replace.out
+++ b/testdata/expected/replace.out
@@ -1,11 +1,11 @@
-PS017: Unqualified object reference: unsafe_agg3
-PS007: Unsafe object creation: unsafe_agg3()
-PS002: Unsafe function creation: unsafe_func4()
-PS005: Function without explicit search_path: unsafe_func4()
-PS002: Unsafe function creation: unsafe_proc5()
-PS005: Function without explicit search_path: unsafe_proc5()
-PS006: Unsafe transform creation: type6
-PS015: Unsafe view creation: view9
-PS017: Unqualified object reference: view9
+PS017: Unqualified object reference: unsafe_agg3 at line 1
+PS007: Unsafe object creation: unsafe_agg3() at line 1
+PS002: Unsafe function creation: unsafe_func4() at line 4
+PS005: Function without explicit search_path: unsafe_func4() at line 4
+PS002: Unsafe function creation: unsafe_proc5() at line 5
+PS005: Function without explicit search_path: unsafe_proc5() at line 5
+PS006: Unsafe transform creation: type6 at line 6
+PS015: Unsafe view creation: view9 at line 7
+PS017: Unqualified object reference: view9 at line 7
 
 Errors: 4 Warnings: 5 Unknown: 0

--- a/testdata/expected/search_path.out
+++ b/testdata/expected/search_path.out
@@ -1,5 +1,5 @@
-PS016: Unqualified function call: unsafe_call3
-PS016: Unqualified function call: unsafe_call15
-PS016: Unqualified function call: unsafe_call21
+PS016: Unqualified function call: unsafe_call3 at line 2
+PS016: Unqualified function call: unsafe_call15 at line 13
+PS016: Unqualified function call: unsafe_call21 at line 21
 
 Errors: 0 Warnings: 3 Unknown: 0

--- a/testdata/expected/security_definer.out
+++ b/testdata/expected/security_definer.out
@@ -1,8 +1,8 @@
-PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer2()
-PS016: Unqualified function call: now
-PS005: Function without explicit search_path: safe_sec_invoker4()
-PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer6()
-PS005: Function without explicit search_path: safe_sec_definer8()
-PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer10()
+PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer2() at line 1
+PS016: Unqualified function call: now at line 1
+PS005: Function without explicit search_path: safe_sec_invoker4() at line 3
+PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer6() at line 5
+PS005: Function without explicit search_path: safe_sec_definer8() at line 7
+PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer10() at line 9
 
 Errors: 3 Warnings: 3 Unknown: 0

--- a/testdata/expected/set_local.out
+++ b/testdata/expected/set_local.out
@@ -1,4 +1,4 @@
-PS016: Unqualified function call: unsafe_call21
-PS016: Unqualified function call: unsafe_call30
+PS016: Unqualified function call: unsafe_call21 at line 19
+PS016: Unqualified function call: unsafe_call30 at line 28
 
 Errors: 0 Warnings: 2 Unknown: 0

--- a/testdata/expected/sql_function.out
+++ b/testdata/expected/sql_function.out
@@ -1,9 +1,9 @@
-PS005: Function without explicit search_path: sqlfunc()
-PS016: Unqualified function call: unsafe_call3
-PS005: Function without explicit search_path: sqlfunc()
-PS016: Unqualified function call: unsafe_call10
-PS005: Function without explicit search_path: sqlfunc()
-PS016: Unqualified function call: unsafe_call13
-PS016: Unqualified function call: unsafe_call17
+PS005: Function without explicit search_path: sqlfunc() at line 2
+PS016: Unqualified function call: unsafe_call3 at line 2
+PS005: Function without explicit search_path: sqlfunc() at line 10
+PS016: Unqualified function call: unsafe_call10 at line 10
+PS005: Function without explicit search_path: sqlfunc() at line 11
+PS016: Unqualified function call: unsafe_call13 at line 11
+PS016: Unqualified function call: unsafe_call17 at line 11
 
 Errors: 0 Warnings: 7 Unknown: 0

--- a/testdata/expected/unqualified_cte.out
+++ b/testdata/expected/unqualified_cte.out
@@ -1,3 +1,3 @@
-PS017: Unqualified object reference: foo
+PS017: Unqualified object reference: foo at line 1
 
 Errors: 0 Warnings: 1 Unknown: 0

--- a/visitors.py
+++ b/visitors.py
@@ -8,7 +8,7 @@ from state import State
 import re
 
 
-def visit_sql(state, sql, searchpath_secure=False):
+def visit_sql(state, sql, searchpath_secure=False, toplevel=False):
     # We have to iterate over toplevel items ourselves cause the visitor does
     # breadth-first iteration, which would conflict with our search_path state
     # tracking.
@@ -24,8 +24,13 @@ def visit_sql(state, sql, searchpath_secure=False):
     # SQL, so we comment out all psql meta commands before parsing.
     sql = re.sub(r"^\\", "-- \\\\", sql, flags=re.MULTILINE)
 
+    if toplevel:
+        state.counter.sql = sql
+
     visitor = SQLVisitor(state)
     for stmt in parse_sql(sql):
+        if toplevel:
+            state.counter.stmt_location = stmt.stmt_location
         visitor(stmt)
 
 


### PR DESCRIPTION
Unfortunately the line_number handling is not perfect.
This will be the line of the first character after the
previous statement has ended. On files with comments
before a statement it will indicate the line with comments
instead of the line with the actual statement.