### PR TITLE
Handle unqualified casts

### DIFF
--- a/testdata/cast.sql
+++ b/testdata/cast.sql
@@ -1,0 +1,20 @@
+-- safe: int is automatically interpreted as pg_catalog.int
+SELECT 1::int;
+
+-- safe: int4 is the built-in pg_catalog.int4
+SELECT 1::pg_catalog.int4;
+
+-- unsafe: the cast is to a custom type, and the type is unqualified
+SELECT 1::custom_type;
+
+-- safe: the cast is to a schema-qualified custom type
+SELECT 1::custom_schema.type;
+
+-- unsafe: the destination type is not fully-qualified
+SELECT '1'::int4;
+
+-- unsafe: the destination type is not fully-qualified
+SELECT int4 '1';
+
+-- unsafe: the destination type is not fully-qualified
+SELECT CAST('1' AS int4);

--- a/testdata/expected/cast.out
+++ b/testdata/expected/cast.out
@@ -1,0 +1,6 @@
+PS017: Unqualified object reference: custom_type in CAST(1 AS custom_type)
+PS017: Unqualified object reference: int4 in CAST('1' AS int4)
+PS017: Unqualified object reference: int4 in CAST('1' AS int4)
+PS017: Unqualified object reference: int4 in CAST('1' AS int4)
+
+Errors: 4 Warnings: 0 Unknown: 0

--- a/visitors.py
+++ b/visitors.py
@@ -249,6 +249,13 @@ class SQLVisitor(Visitor):
         ):
             self.state.error("PS014", "{}".format(format_name(node.idxname)))
 
+    def visit_TypeCast(self, ancestors, node):
+        if len(node.typeName.names) == 1 and not self.state.searchpath_secure:
+            self.state.error(
+                "PS017",
+                "{} in {}".format(format_name(node.typeName.names), RawStream()(node)),
+            )
+
     def visit_ViewStmt(self, ancestors, node):
         if (
             "schemaname" in node.view


### PR DESCRIPTION
It is possible for a malicious user to craft a custom type, with
associated (malicious) cast function and cause it to be used when the
typecast is not schema-qualified.
