### PR TITLE
Dont raise exception on unknown DO block language

### DIFF
--- a/testdata/do.sql
+++ b/testdata/do.sql
@@ -21,3 +21,9 @@ BEGIN
   $i$;
 END;
 $$;
+
+-- unknown language
+DO LANGUAGE PLLUA $$
+  print("Hello World")
+$$;
+

--- a/testdata/expected/do.out
+++ b/testdata/expected/do.out
@@ -3,5 +3,6 @@ PS016: Unqualified function call: unsafe_call3 at line 3
 PS016: Unqualified function call: unsafe_call8 at line 4
 PS016: Unqualified function call: unsafe_call10 at line 4
 PS016: Unqualified function call: unsafe_call19 at line 4
+Unknown language: pllua
 
-Errors: 0 Warnings: 5 Unknown: 0
+Errors: 0 Warnings: 5 Unknown: 1

--- a/visitors.py
+++ b/visitors.py
@@ -282,7 +282,7 @@ class SQLVisitor(Visitor):
             case "plpgsql":
                 visit_plpgsql(self.state, node, self.state.searchpath_secure)
             case _:
-                raise Exception("Unknown language: {}".format(language))
+                self.state.unknown("Unknown language: {}".format(language))
 
     def visit_FuncCall(self, ancestors, node):
         if len(node.funcname) != 2 and not self.state.searchpath_secure:


### PR DESCRIPTION
Change the code to log unknown DO block languages instead of raising
exception and aborting processing.