### PR TITLE
Add per file counter tracking in multiple file mode

### DIFF
--- a/pgspot
+++ b/pgspot
@@ -29,13 +29,25 @@ if args.files:
     visit_sql(State(counter), data, toplevel=True)
 
   else:
+    linebreak = '' if args.summary_only else '\n'
     # process each file individually
     for f in args.files:
       if len(args.files) > 1:
-        print("\n{}\n".format(f))
+        print("{}: ".format(f), end=linebreak)
       data = open(f).read()
 
-      visit_sql(State(counter), data, toplevel=True)
+      file_counter = Counter(args)
+      try:
+        visit_sql(State(file_counter), data, toplevel=True)
+      except Exception as err:
+        print(linebreak, file_counter, linebreak, err)
+      else:
+        print(linebreak, file_counter, linebreak)
+
+      counter.add(file_counter)
+
+    if len(args.files) > 1:
+      print('TOTAL:', counter)
 
 elif args.explain:
   code = args.explain
@@ -52,7 +64,7 @@ else:
 
   visit_sql(State(counter), data, toplevel=True)
 
-print(counter)
+  print(counter)
 
 if not counter.is_clean():
   sys.exit(1)

--- a/state.py
+++ b/state.py
@@ -14,6 +14,11 @@ class Counter:
         self.sql = ""
         self.stmt_location = 0
 
+    def add(self, counter):
+        self.warnings += counter.warnings
+        self.unknowns += counter.unknowns
+        self.errors += counter.errors
+
     def print_issue(self, code, context):
         if code not in codes:
             raise ValueError
@@ -55,7 +60,7 @@ class Counter:
         return self.errors + self.warnings + self.unknowns == 0
 
     def __str__(self):
-        return "\nErrors: {} Warnings: {} Unknown: {}".format(
+        return "Errors: {} Warnings: {} Unknown: {}".format(
             self.errors, self.warnings, self.unknowns
         )
 

--- a/testdata/expected/aggregate_tracking.out
+++ b/testdata/expected/aggregate_tracking.out
@@ -7,4 +7,5 @@ PS007: Unsafe object creation: s1.agg6(integer,integer) at line 13
 PS007: Unsafe object creation: s3.agg14(int8) at line 21
 PS007: Unsafe object creation: s3.agg14(int8) at line 23
 
-Errors: 7 Warnings: 1 Unknown: 0
+ Errors: 7 Warnings: 1 Unknown: 0 
+

--- a/testdata/expected/cast.out
+++ b/testdata/expected/cast.out
@@ -3,4 +3,5 @@ PS017: Unqualified object reference: int4 in CAST('1' AS int4) at line 12
 PS017: Unqualified object reference: int4 in CAST('1' AS int4) at line 15
 PS017: Unqualified object reference: int4 in CAST('1' AS int4) at line 18
 
-Errors: 4 Warnings: 0 Unknown: 0
+ Errors: 4 Warnings: 0 Unknown: 0 
+

--- a/testdata/expected/created_schema.out
+++ b/testdata/expected/created_schema.out
@@ -1,2 +1,3 @@
 
-Errors: 0 Warnings: 0 Unknown: 0
+ Errors: 0 Warnings: 0 Unknown: 0 
+

--- a/testdata/expected/createfunc.out
+++ b/testdata/expected/createfunc.out
@@ -11,4 +11,5 @@ PS005: Function without explicit search_path: f8(integer) at line 12
 PS005: Function without explicit search_path: safe16() at line 15
 PS016: Unqualified function call: unsafe_call18 at line 15
 
-Errors: 2 Warnings: 10 Unknown: 0
+ Errors: 2 Warnings: 10 Unknown: 0 
+

--- a/testdata/expected/do.out
+++ b/testdata/expected/do.out
@@ -5,4 +5,5 @@ PS016: Unqualified function call: unsafe_call10 at line 4
 PS016: Unqualified function call: unsafe_call19 at line 4
 Unknown language: pllua
 
-Errors: 0 Warnings: 5 Unknown: 1
+ Errors: 0 Warnings: 5 Unknown: 1 
+

--- a/testdata/expected/exists.out
+++ b/testdata/expected/exists.out
@@ -15,4 +15,5 @@ PS017: Unqualified object reference: table10 at line 10
 PS007: Unsafe object creation: table11 at line 11
 PS017: Unqualified object reference: table11 at line 11
 
-Errors: 9 Warnings: 7 Unknown: 0
+ Errors: 9 Warnings: 7 Unknown: 0 
+

--- a/testdata/expected/nested_searchpath.out
+++ b/testdata/expected/nested_searchpath.out
@@ -9,4 +9,5 @@ PS016: Unqualified function call: unsafe_call19 at line 20
 PS005: Function without explicit search_path: f25_nested_no_path() at line 23
 PS016: Unqualified function call: unsafe_call25 at line 23
 
-Errors: 0 Warnings: 10 Unknown: 0
+ Errors: 0 Warnings: 10 Unknown: 0 
+

--- a/testdata/expected/operator.out
+++ b/testdata/expected/operator.out
@@ -1,3 +1,4 @@
 PS017: Unqualified object reference: #? at line 2
 
-Errors: 0 Warnings: 1 Unknown: 0
+ Errors: 0 Warnings: 1 Unknown: 0 
+

--- a/testdata/expected/plpgsql_function.out
+++ b/testdata/expected/plpgsql_function.out
@@ -10,4 +10,5 @@ PS005: Function without explicit search_path: plpgsqlfunc16() at line 14
 PS016: Unqualified function call: unsafe_call17 at line 14
 PS016: Unqualified function call: unsafe_call21 at line 14
 
-Errors: 0 Warnings: 11 Unknown: 0
+ Errors: 0 Warnings: 11 Unknown: 0 
+

--- a/testdata/expected/ps009-simplified-case.out
+++ b/testdata/expected/ps009-simplified-case.out
@@ -1,3 +1,4 @@
 PS009: Unsafe CASE expression: CASE a OPERATOR(pg_catalog.=) b WHEN TRUE THEN 'true' WHEN FALSE THEN 'false' END at line 1
 
-Errors: 1 Warnings: 0 Unknown: 0
+ Errors: 1 Warnings: 0 Unknown: 0 
+

--- a/testdata/expected/range_function.out
+++ b/testdata/expected/range_function.out
@@ -1,4 +1,5 @@
 PS016: Unqualified function call: unsafe_call1 at line 1
 PS016: Unqualified function call: unsafe_call2 at line 2
 
-Errors: 0 Warnings: 2 Unknown: 0
+ Errors: 0 Warnings: 2 Unknown: 0 
+

--- a/testdata/expected/replace.out
+++ b/testdata/expected/replace.out
@@ -8,4 +8,5 @@ PS006: Unsafe transform creation: type6 at line 6
 PS015: Unsafe view creation: view9 at line 7
 PS017: Unqualified object reference: view9 at line 7
 
-Errors: 4 Warnings: 5 Unknown: 0
+ Errors: 4 Warnings: 5 Unknown: 0 
+

--- a/testdata/expected/search_path.out
+++ b/testdata/expected/search_path.out
@@ -2,4 +2,5 @@ PS016: Unqualified function call: unsafe_call3 at line 2
 PS016: Unqualified function call: unsafe_call15 at line 13
 PS016: Unqualified function call: unsafe_call21 at line 21
 
-Errors: 0 Warnings: 3 Unknown: 0
+ Errors: 0 Warnings: 3 Unknown: 0 
+

--- a/testdata/expected/security_definer.out
+++ b/testdata/expected/security_definer.out
@@ -5,4 +5,5 @@ PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_define
 PS005: Function without explicit search_path: safe_sec_definer8() at line 7
 PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer10() at line 9
 
-Errors: 3 Warnings: 3 Unknown: 0
+ Errors: 3 Warnings: 3 Unknown: 0 
+

--- a/testdata/expected/set_local.out
+++ b/testdata/expected/set_local.out
@@ -1,4 +1,5 @@
 PS016: Unqualified function call: unsafe_call21 at line 19
 PS016: Unqualified function call: unsafe_call30 at line 28
 
-Errors: 0 Warnings: 2 Unknown: 0
+ Errors: 0 Warnings: 2 Unknown: 0 
+

--- a/testdata/expected/sql_function.out
+++ b/testdata/expected/sql_function.out
@@ -6,4 +6,5 @@ PS005: Function without explicit search_path: sqlfunc() at line 11
 PS016: Unqualified function call: unsafe_call13 at line 11
 PS016: Unqualified function call: unsafe_call17 at line 11
 
-Errors: 0 Warnings: 7 Unknown: 0
+ Errors: 0 Warnings: 7 Unknown: 0 
+

--- a/testdata/expected/unqualified_cte.out
+++ b/testdata/expected/unqualified_cte.out
@@ -1,3 +1,4 @@
 PS017: Unqualified object reference: foo at line 1
 
-Errors: 0 Warnings: 1 Unknown: 0
+ Errors: 0 Warnings: 1 Unknown: 0 
+


### PR DESCRIPTION
This patch adds per file counter output in multiple file mode
and makes the output in summary mode much terser.

Summary output with multiple files:
```
%  ./pgspot --summary testdata/ps009-simplified-case.sql testdata/range_function.sql testdata/set_local.sql testdata/unqualified_cte.sql
testdata/ps009-simplified-case.sql:  Errors: 1 Warnings: 0 Unknown: 0
testdata/range_function.sql:  Errors: 0 Warnings: 2 Unknown: 0
testdata/set_local.sql:  Errors: 0 Warnings: 2 Unknown: 0
testdata/unqualified_cte.sql:  Errors: 0 Warnings: 1 Unknown: 0
TOTAL: Errors: 1 Warnings: 5 Unknown: 0
```

Example with multiple files:
```
%  ./pgspot testdata/ps009-simplified-case.sql testdata/range_function.sql testdata/set_local.sql testdata/unqualified_cte.sql
testdata/ps009-simplified-case.sql:
PS009: Unsafe CASE expression: CASE a OPERATOR(pg_catalog.=) b WHEN TRUE THEN 'true' WHEN FALSE THEN 'false' END at line 1

 Errors: 1 Warnings: 0 Unknown: 0

testdata/range_function.sql:
PS016: Unqualified function call: unsafe_call1 at line 1
PS016: Unqualified function call: unsafe_call2 at line 2

 Errors: 0 Warnings: 2 Unknown: 0

testdata/set_local.sql:
PS016: Unqualified function call: unsafe_call21 at line 19
PS016: Unqualified function call: unsafe_call30 at line 28

 Errors: 0 Warnings: 2 Unknown: 0

testdata/unqualified_cte.sql:
PS017: Unqualified object reference: foo at line 1

 Errors: 0 Warnings: 1 Unknown: 0

TOTAL: Errors: 1 Warnings: 5 Unknown: 0
```