### PR TITLE
Don't warn about search_path of C SECURITY DEFINER

### DIFF
--- a/testdata/security_definer.sql
+++ b/testdata/security_definer.sql
@@ -8,4 +8,5 @@ CREATE FUNCTION unsafe_sec_definer6() RETURNS TEXT LANGUAGE PLPGSQL SECURITY DEF
 CREATE FUNCTION safe_sec_definer8() RETURNS TEXT LANGUAGE PLPGSQL SECURITY INVOKER AS $$ BEGIN RETURN pg_catalog.now(); END; $$;
 -- unsafe plpgsql sec definer procedure with no search_path
 CREATE PROCEDURE unsafe_sec_definer10() LANGUAGE PLPGSQL SECURITY DEFINER AS $$ BEGIN PERFORM pg_catalog.now(); END; $$;
-
+-- we dont warn about search_path of security definer function in C
+CREATE FUNCTION c_sec_definer12() RETURNS TEXT LANGUAGE C SECURITY DEFINER AS 'c_sec_definer12';

--- a/visitors.py
+++ b/visitors.py
@@ -136,7 +136,7 @@ class SQLVisitor(Visitor):
             body_secure = False
 
         # functions without explicit search_path will generate a warning unless they are SECURITY DEFINER
-        if security:
+        if security and language != "c":
             if not setter:
                 self.state.error("PS003", "{}".format(format_function(node)))
             elif not body_secure:


### PR DESCRIPTION
Since we cannot check C function code we don't warn about SECURITY
DEFINER functions without search_path implemented in C.