### PR TITLE
Fix search_path evaluation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -24,7 +24,7 @@ To mitigate, either
 a) explicitly set the search path:
 
 ```
-SET search_path = pg_catalog;
+SET search_path = pg_catalog, pg_temp;
 SELECT foo + bar;
 ```
 
@@ -85,13 +85,13 @@ In particular, it is highly advised to set a fixed, secure `search_path` for
 these functions, as it prevents a number of attacks which rely on an insecure
 `search_path`.
 
-To mitigate, set the `search_path` to the secure search path `pg_catalog`
+To mitigate, set the `search_path` to the secure search path `pg_catalog, pg_temp`
 
 ```
 CREATE FUNCTION my_extension.security_definer_function()
     RETURNS VOID
     SECURITY DEFINER
-    SET search_path = pg_catalog
+    SET search_path = pg_catalog, pg_temp
     LANGUAGE SQL
 AS $$
     -- function body
@@ -122,13 +122,13 @@ In particular, it is highly advised to set a fixed, secure `search_path` for
 these functions, as it prevents a number of attacks which rely on an insecure
 `search_path`.
 
-To mitigate, set the `search_path` to the secure search path `pg_catalog`
+To mitigate, set the `search_path` to the secure search path `pg_catalog, pg_temp`
 
 ```
 CREATE FUNCTION my_extension.security_definer_function()
     RETURNS VOID
     SECURITY DEFINER
-    SET search_path = pg_catalog
+    SET search_path = pg_catalog, pg_temp
     LANGUAGE SQL
 AS $$
     -- function body
@@ -152,12 +152,12 @@ $$;
 In general, it is preferable to define an explicit search path for functions,
 as this can prevent insecure search_path attacks.
 
-To mitigate, set the `search_path` to the secure search path `pg_catalog`
+To mitigate, set the `search_path` to the secure search path `pg_catalog, pg_temp`
 
 ```
 CREATE FUNCTION my_extension.function()
     RETURNS VOID
-    SET search_path = pg_catalog
+    SET search_path = pg_catalog, pg_temp
     LANGUAGE SQL
 AS $$
     -- function body
@@ -244,7 +244,7 @@ To mitigate, either
 a) explicitly set the search path:
 
 ```
-SET search_path = pg_catalog;
+SET search_path = pg_catalog, pg_temp;
 SELECT
     CASE a = b
         WHEN true THEN 'true'
@@ -434,7 +434,7 @@ first.
 Either a) explicitly set the search path.
 
 ```
-SET search_path = pg_catalog;
+SET search_path = pg_catalog, pg_temp;
 SELECT my_function(foo);
 ```
 

--- a/codes.py
+++ b/codes.py
@@ -22,7 +22,7 @@ codes = {
         a) explicitly set the search path:
         
         ```
-        SET search_path = pg_catalog;
+        SET search_path = pg_catalog, pg_temp;
         SELECT foo + bar;
         ```
         
@@ -89,13 +89,13 @@ codes = {
         these functions, as it prevents a number of attacks which rely on an insecure
         `search_path`.
         
-        To mitigate, set the `search_path` to the secure search path `pg_catalog`
+        To mitigate, set the `search_path` to the secure search path `pg_catalog, pg_temp`
         
         ```
         CREATE FUNCTION my_extension.security_definer_function()
             RETURNS VOID
             SECURITY DEFINER
-            SET search_path = pg_catalog
+            SET search_path = pg_catalog, pg_temp
             LANGUAGE SQL
         AS $$
             -- function body
@@ -129,13 +129,13 @@ codes = {
         these functions, as it prevents a number of attacks which rely on an insecure
         `search_path`.
         
-        To mitigate, set the `search_path` to the secure search path `pg_catalog`
+        To mitigate, set the `search_path` to the secure search path `pg_catalog, pg_temp`
         
         ```
         CREATE FUNCTION my_extension.security_definer_function()
             RETURNS VOID
             SECURITY DEFINER
-            SET search_path = pg_catalog
+            SET search_path = pg_catalog, pg_temp
             LANGUAGE SQL
         AS $$
             -- function body
@@ -162,12 +162,12 @@ codes = {
         In general, it is preferable to define an explicit search path for functions,
         as this can prevent insecure search_path attacks.
         
-        To mitigate, set the `search_path` to the secure search path `pg_catalog`
+        To mitigate, set the `search_path` to the secure search path `pg_catalog, pg_temp`
         
         ```
         CREATE FUNCTION my_extension.function()
             RETURNS VOID
-            SET search_path = pg_catalog
+            SET search_path = pg_catalog, pg_temp
             LANGUAGE SQL
         AS $$
             -- function body
@@ -266,7 +266,7 @@ codes = {
         a) explicitly set the search path:
         
         ```
-        SET search_path = pg_catalog;
+        SET search_path = pg_catalog, pg_temp;
         SELECT
             CASE a = b
                 WHEN true THEN 'true'
@@ -477,7 +477,7 @@ codes = {
         Either a) explicitly set the search path.
         
         ```
-        SET search_path = pg_catalog;
+        SET search_path = pg_catalog, pg_temp;
         SELECT my_function(foo);
         ```
         

--- a/testdata/do.sql
+++ b/testdata/do.sql
@@ -11,7 +11,7 @@ BEGIN
     PERFORM unsafe_call10();
   END;
   $i$;
-  SET search_path TO pg_catalog;
+  SET search_path TO pg_catalog,pg_temp;
   DO $i$
   BEGIN
     PERFORM safe_call17();

--- a/testdata/nested_searchpath.sql
+++ b/testdata/nested_searchpath.sql
@@ -1,7 +1,7 @@
 
 SELECT unsafe_call2();
 
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 
 SELECT safe_call6();
 
@@ -14,14 +14,14 @@ RESET search_path;
 -- unsafe because search_path is not locked down
 DO $$ BEGIN SELECT unsafe_call_in_do14(); END; $$;
 
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 
 CREATE FUNCTION f18_no_path() RETURNS TEXT LANGUAGE SQL AS $$ SELECT unsafe_call18(); $$;
 CREATE FUNCTION f19_path() RETURNS TEXT LANGUAGE SQL SET search_path TO public AS $$ SELECT unsafe_call19(); $$;
 
-CREATE FUNCTION f21_path() RETURNS TEXT LANGUAGE SQL SET search_path TO pg_catalog AS $$ SELECT safe_call21(); $$;
+CREATE FUNCTION f21_path() RETURNS TEXT LANGUAGE SQL SET search_path TO pg_catalog, pg_temp AS $$ SELECT safe_call21(); $$;
 
-CREATE FUNCTION f23_path() RETURNS TEXT LANGUAGE SQL SET search_path TO pg_catalog AS $$
+CREATE FUNCTION f23_path() RETURNS TEXT LANGUAGE SQL SET search_path TO pg_catalog, pg_temp AS $$
   -- search_path is not inherited in inner function body
   CREATE FUNCTION f25_nested_no_path() RETURNS TEXT LANGUAGE SQL AS $f1$ SELECT unsafe_call25(); $f1$;
 $$;

--- a/testdata/plpgsql_function.sql
+++ b/testdata/plpgsql_function.sql
@@ -5,18 +5,18 @@ CREATE FUNCTION plpgsqlfunc4() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN PERFORM
 CREATE FUNCTION plpgsqlfunc5() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN RETURN unsafe_call5(); END; $$;
 
 -- safe call inside function
-CREATE FUNCTION plpgsqlfunc7() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN SELECT safe_call7(); END; $$ SET search_path TO 'pg_catalog';
-CREATE FUNCTION plpgsqlfunc8() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN PERFORM safe_call8(); END; $$ SET search_path TO 'pg_catalog';
+CREATE FUNCTION plpgsqlfunc7() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN SELECT safe_call7(); END; $$ SET search_path TO 'pg_catalog', 'pg_temp';
+CREATE FUNCTION plpgsqlfunc8() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN PERFORM safe_call8(); END; $$ SET search_path TO 'pg_catalog', 'pg_temp';
 
 -- unsafe call inside function, since search_path for body is not safe
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 CREATE FUNCTION plpgsqlfunc13() RETURNS TEXT LANGUAGE PLPGSQL AS $$ BEGIN SELECT unsafe_call13(); END; $$;
 
 CREATE FUNCTION plpgsqlfunc16() RETURNS TEXT LANGUAGE PLPGSQL AS $$
 BEGIN
   ASSERT true;
   SELECT unsafe_call17();
-  SET search_path TO pg_catalog;
+  SET search_path TO pg_catalog, pg_temp;
   SELECT safe_call19();
   RESET search_path;
   SELECT unsafe_call21();

--- a/testdata/search_path.sql
+++ b/testdata/search_path.sql
@@ -3,7 +3,7 @@
 SELECT unsafe_call3('%s','abc');
 SELECT pg_catalog.safe_call4();
 
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 
 -- safe since we have safe search_path now
 SELECT safe_call9('%s','abc');

--- a/testdata/set_local.sql
+++ b/testdata/set_local.sql
@@ -1,5 +1,5 @@
 
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 
 -- safe since search_path is locked down
 SELECT safe_call5();
@@ -12,7 +12,7 @@ SELECT safe_call10();
 RESET search_path;
 
 BEGIN;
-SET LOCAL search_path TO pg_catalog;
+SET LOCAL search_path TO pg_catalog, pg_temp;
 -- safe since search_path is still locked down
 SELECT safe_call17();
 COMMIT;
@@ -21,7 +21,7 @@ COMMIT;
 SELECT unsafe_call21();
 
 BEGIN;
-SET LOCAL search_path TO pg_catalog;
+SET LOCAL search_path TO pg_catalog, pg_temp;
 -- safe since search_path is still locked down
 SELECT safe_call26();
 ROLLBACK;

--- a/testdata/sql_function.sql
+++ b/testdata/sql_function.sql
@@ -3,15 +3,15 @@
 CREATE FUNCTION sqlfunc() RETURNS TEXT LANGUAGE SQL AS $$ SELECT unsafe_call3(); $$;
 
 -- safe call inside function
-CREATE FUNCTION sqlfunc() RETURNS TEXT LANGUAGE SQL AS $$ SELECT safe_call6(); $$ SET search_path TO 'pg_catalog';
+CREATE FUNCTION sqlfunc() RETURNS TEXT LANGUAGE SQL AS $$ SELECT safe_call6(); $$ SET search_path TO 'pg_catalog', 'pg_temp';
 
 -- unsafe call inside function, since search_path for body is not safe
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 CREATE FUNCTION sqlfunc() RETURNS TEXT LANGUAGE SQL AS $$ SELECT unsafe_call10(); $$;
 
 CREATE FUNCTION sqlfunc() RETURNS TEXT LANGUAGE SQL AS $$
 SELECT unsafe_call13();
-SET search_path TO pg_catalog;
+SET search_path TO pg_catalog, pg_temp;
 SELECT safe_call15();
 RESET search_path;
 SELECT unsafe_call17();

--- a/visitors.py
+++ b/visitors.py
@@ -131,7 +131,7 @@ class SQLVisitor(Visitor):
         ]
 
         if setter:
-            body_secure = self.state.is_secure_searchpath(setter)
+            body_secure = self.state.is_secure_searchpath(setter[0])
         else:
             body_secure = False
 


### PR DESCRIPTION
This patch changes pg_spot to no longer consider a search_path
without pg_temp safe. While postgres will ignore pg_temp for any
function or operator lookup this is not true for relations.
If pg_temp is not present in search_path postgres will prepend
it to the search_path meaning that any relation present in pg_temp
will shadow any similarly named objects. With this patch pgspot
will consider a search_path safe if it has explicit pg_temp as
last entry.