### PR TITLE
Fix nightly CI run on timescaledb main branch

### DIFF
--- a/.github/workflows/timescaledb.yml
+++ b/.github/workflows/timescaledb.yml
@@ -17,18 +17,9 @@ jobs:
     - name: Checkout pgspot
       uses: actions/checkout@v2
 
-    - name: Checkout pglast
-      uses: actions/checkout@v2
-      with:
-        repository: 'svenklemm/pglast'
-        submodules: true
-        path: 'pglast'
-
-    - name: Install packages
+    - name: Install pgspot
       run: |
-        python -m pip install wheel
-        python -m pip install --force-reinstall ./pglast
-        python -m pip install pytest pytest-snapshot
+        python -m pip install .
 
     - name: Checkout timescaledb
       uses: actions/checkout@v2
@@ -48,7 +39,7 @@ jobs:
     # do not have explicit search_path because this would prevent them doing transaction control
     - name: Run pgspot
       run: |
-        python pgspot \
+        pgspot \
           --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts timestamp,"offset" interval)' \
           --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts timestamptz,"offset" interval)' \
           --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts date,"offset" interval)' \


### PR DESCRIPTION
Due to repository layout changes you cannot easily run pgspot
directly from repository anymore. But it can be installed with pip
now so this patch adjusts the workflow to use pip.