### PR TITLE
Update to use pglast>=3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ pip install git+https://github.com/timescale/pgspot.git
 ## Requirements
 
 - python >= 3.10
-- [pglast](https://github.com/lelit/pglast) ([recommended fork](https://github.com/svenklemm/pglast))
+- [pglast >= 3.10](https://github.com/lelit/pglast)
 - [libpg_query](https://github.com/pganalyze/libpg_query) (indirectly through pglast)
 
 To install the runtime requirements, use `pip -r requirements.txt`.
 
-Currently it is recommended to use the forked version of pglast as it pulls in some libpg_query changes ([9aad9fdb](https://github.com/pganalyze/libpg_query/commit/9aad9fdbd78a9cdb09cc8eb24adc703887c9e76d) and [a53865a4](https://github.com/pganalyze/libpg_query/commit/a53865a45fe1530fcd9ba3476986559a75de4d8d)) affecting pgspot functionality that are not part of the last release.
 
 ### Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pglast @ git+https://github.com/svenklemm/pglast@01853619c0ecc4fe531bb0cdbe1207cd090dcc71
+pglast>=3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 python_requires = >= 3.10
 
 install_requires =
-    pglast @ git+https://github.com/svenklemm/pglast@01853619c0ecc4fe531bb0cdbe1207cd090dcc71#egg=pglast-3.8
+    pglast>=3.10
 
 tests_require =
     pytest

--- a/shell.nix
+++ b/shell.nix
@@ -11,14 +11,14 @@ let
   # Use svenklemm's fork of pglast, which adds support for SET, COMMIT, ROLLBACK, CALL
   pglast = pkgs.python310Packages.buildPythonPackage rec {
     name = "pglast";
-    version = "01853619c0ecc4fe531bb0cdbe1207cd090dcc71";
+    version = "v3.10";
 
     src = pkgs.fetchFromGitHub {
-      owner = "svenklemm";
+      owner = "lelit";
       repo = "${name}";
       rev = "${version}";
       fetchSubmodules = true;
-      sha256 = "sha256-TVlF9BIj3M6ojItuIY7g9oOPfPJ2bfS1utRtqlk0IlU";
+      sha256 = "sha256-lBAhdqLTt7x/NYYfgcMm/qk04r4YuLDeWYmI8WaMZm8=";
     };
   };
 


### PR DESCRIPTION
pglast has released 3.10 with our upstream contributions to libpg_query,
so we don't need to use our fork anymore.