### PR TITLE
Add `dist` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 __pycache__
 .pytest_cache
 .tox
+dist


### PR DESCRIPTION
This directory is created when building packages, and can be ignored.