### PR TITLE
Use absolute link to REFERENCE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ pgspot checks for the following vulnerabilities:
 - search_path-based attacks
 - unsafe object creation
 
-Consult the [reference](REFERENCE.md) for detailed documentation of the
-vulnerabilities which pgspot detects, and their potential mitigations.
+Consult the [reference] for detailed documentation of the vulnerabilities which
+pgspot detects, and their potential mitigations.
+
+[reference]: https://github.com/timescale/pgspot/blob/main/REFERENCE.md
 
 ## Useful links
 - [PostgreSQL security recommendations for extensions](https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-SECURITY)


### PR DESCRIPTION
The relative link breaks in the display on [pypi] because it doesn't
host that page.

[pypi]: https://pypi.org/project/pgspot/