### PR TITLE
Support set_config('search_path',...)

### DIFF
--- a/src/pgspot/formatters.py
+++ b/src/pgspot/formatters.py
@@ -6,6 +6,18 @@ def raw_sql(node):
     return RawStream()(node)
 
 
+def get_text(node):
+    match (node):
+        case str():
+            return node
+        case ast.A_Const():
+            return get_text(node.val)
+        case ast.String():
+            return node.val
+        case _:
+            return str(node)
+
+
 def format_name(name):
     match (name):
         case str():
@@ -22,7 +34,7 @@ def format_name(name):
         case ast.TypeName():
             return ".".join([format_name(p) for p in name.names])
         case _:
-            return name
+            return str(name)
 
 
 def format_function(node):

--- a/src/pgspot/state.py
+++ b/src/pgspot/state.py
@@ -1,5 +1,6 @@
 from pglast import ast
 from .codes import codes
+from .formatters import get_text
 
 
 class Counter:
@@ -84,9 +85,9 @@ class State:
     def unknown(self, message):
         self.counter.unknown(message)
 
-    def set_searchpath(self, stmt):
+    def set_searchpath(self, stmt, local=False):
         self.searchpath_secure = self.is_secure_searchpath(stmt)
-        self.searchpath_local = stmt.is_local
+        self.searchpath_local = local
 
     def reset_searchpath(self):
         self.searchpath_secure = False
@@ -99,7 +100,7 @@ class State:
             case list():
                 return setters
             case ast.VariableSetStmt():
-                return [item.val.val for item in setters.args]
+                return [get_text(item) for item in setters.args]
             case _:
                 raise Exception("Unhandled type in extract_schemas: {}".format(setters))
 

--- a/testdata/expected/search_path.out
+++ b/testdata/expected/search_path.out
@@ -1,6 +1,7 @@
 PS016: Unqualified function call: unsafe_call3 at line 2
 PS016: Unqualified function call: unsafe_call15 at line 13
 PS016: Unqualified function call: unsafe_call21 at line 21
+PS016: Unqualified function call: unsafe_call26 at line 26
 
- Errors: 0 Warnings: 3 Unknown: 0 
+ Errors: 0 Warnings: 4 Unknown: 0 
 

--- a/testdata/search_path.sql
+++ b/testdata/search_path.sql
@@ -20,3 +20,7 @@ CREATE SCHEMA new;
 SELECT new.safe_call20('%s','abc');
 SELECT unsafe_call21('%s','abc');
 
+SELECT pg_catalog.set_config('search_path','pg_catalog,pg_temp',true);
+SELECT safe_call24('%s','abc');
+SELECT pg_catalog.set_config('search_path','public',true);
+SELECT unsafe_call26('%s','abc');


### PR DESCRIPTION
This patch treats set_config('search_path',...) identical to
SET search_path so either variant will update the internal search_path
state.