### PR TITLE
Adjust nightly pgspot run settings

### DIFF
--- a/.github/workflows/timescaledb.yml
+++ b/.github/workflows/timescaledb.yml
@@ -48,6 +48,7 @@ jobs:
           --proc-without-search-path '_timescaledb_internal.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean)' \
           --proc-without-search-path '_timescaledb_internal.cagg_migrate_execute_plan(_cagg_data _timescaledb_catalog.continuous_agg)' \
           --proc-without-search-path 'extschema.cagg_migrate(_cagg regclass,_override boolean = FALSE,_drop_old boolean = FALSE)' \
+          --proc-without-search-path 'extschema.cagg_migrate(cagg regclass,override boolean = FALSE,drop_old boolean = FALSE)' \
         timescaledb/build/sql/timescaledb--*.sql
 
     - name: Notify slack on failure


### PR DESCRIPTION
The cagg_migrate parameter names has changed so added the new signature to also check functions without explicit search_path.