### PR TITLE
Require pytest >= 7.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
     steps:
 
     - name: Setup python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install tox
       run: python -m pip install tox
@@ -25,7 +25,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: python -m pip install -r requirements-dev.txt
       - run: black --check --diff .
 
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Setup python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/timescaledb.yml
+++ b/.github/workflows/timescaledb.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Setup python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     pglast==4.1
 
 tests_require =
-    pytest
+    pytest>=7.2.0
     pytest-snapshot
 
 [options.packages.find]


### PR DESCRIPTION
pytest 7.2.0 fixes a ReDoS vulnerability in one of their dependencies.