### PR TITLE
Adjust nightly timescaledb run to schema changes

### DIFF
--- a/.github/workflows/timescaledb.yml
+++ b/.github/workflows/timescaledb.yml
@@ -47,6 +47,9 @@ jobs:
           --proc-without-search-path '_timescaledb_internal.policy_compression(job_id integer,config jsonb)' \
           --proc-without-search-path '_timescaledb_internal.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean)' \
           --proc-without-search-path '_timescaledb_internal.cagg_migrate_execute_plan(_cagg_data _timescaledb_catalog.continuous_agg)' \
+          --proc-without-search-path '_timescaledb_functions.policy_compression(job_id integer,config jsonb)' \
+          --proc-without-search-path '_timescaledb_functions.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean)' \
+          --proc-without-search-path '_timescaledb_functions.cagg_migrate_execute_plan(_cagg_data _timescaledb_catalog.continuous_agg)' \
           --proc-without-search-path 'extschema.cagg_migrate(cagg regclass,override boolean,drop_old boolean)' \
         timescaledb/build/sql/timescaledb--*.sql
 


### PR DESCRIPTION
timescaledb is moving all functions into a dedicated schema so we need to adjust the configuration to match the new location of these functions.