### PR TITLE
Publish using pypi trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ jobs:
   publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -24,6 +25,3 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Pypi introduced the concept of trusted publishers, which uses OIDC to authenticate the publisher of a package, instead of using a long-lived token.