### PR TITLE
Warn about C security definer functions without search_path

### DIFF
--- a/src/pgspot/visitors.py
+++ b/src/pgspot/visitors.py
@@ -240,7 +240,7 @@ class SQLVisitor(Visitor):
 
         # functions without explicit search_path will generate a warning
         # unless they are SECURITY DEFINER
-        if security and language != "c":
+        if security:
             if not setter:
                 self.state.error("PS003", format_function(node))
             elif not body_secure:

--- a/testdata/expected/security_definer.out
+++ b/testdata/expected/security_definer.out
@@ -4,6 +4,7 @@ PS005: Function without explicit search_path: safe_sec_invoker4() at line 3
 PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer6() at line 5
 PS005: Function without explicit search_path: safe_sec_definer8() at line 7
 PS003: SECURITY DEFINER function without explicit search_path: unsafe_sec_definer10() at line 9
+PS003: SECURITY DEFINER function without explicit search_path: c_sec_definer12() at line 11
 
- Errors: 3 Warnings: 3 Unknown: 0 
+ Errors: 4 Warnings: 3 Unknown: 0 
 

--- a/testdata/security_definer.sql
+++ b/testdata/security_definer.sql
@@ -8,5 +8,5 @@ CREATE FUNCTION unsafe_sec_definer6() RETURNS TEXT LANGUAGE PLPGSQL SECURITY DEF
 CREATE FUNCTION safe_sec_definer8() RETURNS TEXT LANGUAGE PLPGSQL SECURITY INVOKER AS $$ BEGIN RETURN pg_catalog.now(); END; $$;
 -- unsafe plpgsql sec definer procedure with no search_path
 CREATE PROCEDURE unsafe_sec_definer10() LANGUAGE PLPGSQL SECURITY DEFINER AS $$ BEGIN PERFORM pg_catalog.now(); END; $$;
--- we dont warn about search_path of security definer function in C
+-- security definer function in C without search_path
 CREATE FUNCTION c_sec_definer12() RETURNS TEXT LANGUAGE C SECURITY DEFINER AS 'c_sec_definer12';


### PR DESCRIPTION
Treat C security definer function similar to how we treat non-C functions and generate the same warning.