### PR TITLE
Update copyright years to include 2023 and 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The PostgreSQL License
 
-Copyright (c) 2022, Timescale, Inc.
+Copyright (c) 2022-2024, Timescale, Inc.
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement


### PR DESCRIPTION
Update the copyright date in the LICENSE to include 2023 and 2024.