### PR TITLE
Change severity of CREATE OR REPLACE FUNCTION

### DIFF
--- a/src/pgspot/visitors.py
+++ b/src/pgspot/visitors.py
@@ -212,7 +212,7 @@ class SQLVisitor(Visitor):
         elif format_function(node) in self.state.created_functions:
             pass
         elif node.replace:
-            self.state.error("PS002", format_function(node))
+            self.state.warn("PS002", format_function(node))
 
         # keep track of functions created in this script in case they get replaced later
         if not node.replace:

--- a/testdata/expected/createfunc.out
+++ b/testdata/expected/createfunc.out
@@ -12,5 +12,5 @@ PS005: Function without explicit search_path: safe16() at line 15
 PS016: Unqualified function call: unsafe_call18 at line 15
 PS002: Unsafe function creation: f22(b integer) at line 26
 
- Errors: 3 Warnings: 10 Unknown: 0 
+ Errors: 0 Warnings: 13 Unknown: 0 
 

--- a/testdata/expected/replace.out
+++ b/testdata/expected/replace.out
@@ -8,5 +8,5 @@ PS006: Unsafe transform creation: type6 at line 6
 PS015: Unsafe view creation: view9 at line 7
 PS017: Unqualified object reference: view9 at line 7
 
- Errors: 4 Warnings: 5 Unknown: 0 
+ Errors: 2 Warnings: 7 Unknown: 0 
 


### PR DESCRIPTION
This patch changes the severity of CREATE OR REPLACE FUNCTION from error to warning as it is not exploitable in an extension script context.