### PR TITLE
Check for misquoted arguments to SET search_path

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -513,3 +513,30 @@ or b) fully-qualify the object
 SELECT * FROM extension_schema.foo;
 ```
 
+## PS018: Unsafe SET search_path
+When using SET search_path the schemas must not be enclosed in single quotes
+as otherwise the list of schemas will be treated as a single schema name instead.
+
+Erroneous example:
+
+```
+SET search_path TO 'pg_catalog, temp';
+```
+
+Setting the search_path this way will result in the actual search_path being
+pg_temp, pg_catalog, "pg_catalog, pg_temp" instead of the intended value of
+pg_catalog, pg_temp. This would allow shadowing catalog relations with relations
+in the pg_temp schema.
+
+To mitigate this do not enclose the list of schemas in single quotes
+
+```
+SET search_path TO pg_catalog, pg_temp;
+```
+
+or b) use pg_catalog.set_config
+
+```
+SELECT pg_catalog.set_config('search_path','pg_catalog, pg_temp', false);
+```
+

--- a/src/pgspot/codes.py
+++ b/src/pgspot/codes.py
@@ -560,4 +560,34 @@ codes = {
         ```
         """,
     },
+    "PS018": {
+        "title": "Unsafe SET search_path",
+        "description": """
+        When using SET search_path the schemas must not be enclosed in single quotes
+        as otherwise the list of schemas will be treated as a single schema name instead.
+
+        Erroneous example:
+
+        ```
+        SET search_path TO 'pg_catalog, temp';
+        ```
+
+        Setting the search_path this way will result in the actual search_path being
+        pg_temp, pg_catalog, "pg_catalog, pg_temp" instead of the intended value of
+        pg_catalog, pg_temp. This would allow shadowing catalog relations with relations
+        in the pg_temp schema.
+
+        To mitigate this do not enclose the list of schemas in single quotes
+
+        ```
+        SET search_path TO pg_catalog, pg_temp;
+        ```
+
+        or b) use pg_catalog.set_config
+
+        ```
+        SELECT pg_catalog.set_config('search_path','pg_catalog, pg_temp', false);
+        ```
+        """,
+    },
 }

--- a/testdata/expected/search_path.out
+++ b/testdata/expected/search_path.out
@@ -2,6 +2,12 @@ PS016: Unqualified function call: unsafe_call3 at line 2
 PS016: Unqualified function call: unsafe_call15 at line 13
 PS016: Unqualified function call: unsafe_call21 at line 21
 PS016: Unqualified function call: unsafe_call26 at line 26
+PS018: Unsafe SET search_path:  at line 27
+PS018: Unsafe SET search_path:  at line 30
+PS005: Function without explicit search_path: f() at line 31
+PS018: Unsafe SET search_path:  at line 31
+PS005: Function without explicit search_path: f() at line 33
+PS018: Unsafe SET search_path:  at line 33
 
- Errors: 0 Warnings: 4 Unknown: 0 
+ Errors: 4 Warnings: 6 Unknown: 0 
 

--- a/testdata/search_path.sql
+++ b/testdata/search_path.sql
@@ -24,3 +24,11 @@ SELECT pg_catalog.set_config('search_path','pg_catalog,pg_temp',true);
 SELECT safe_call24('%s','abc');
 SELECT pg_catalog.set_config('search_path','public',true);
 SELECT unsafe_call26('%s','abc');
+
+-- check for search_path setting with wrong quoting
+SET search_path TO 'pg_catalog, pg_temp';
+SET search_path = 'pg_catalog, pg_temp';
+
+CREATE FUNCTION f() RETURNS VOID AS '' LANGUAGE SQL SET search_path TO 'pg_catalog, pg_temp';
+CREATE FUNCTION f() RETURNS VOID AS '' LANGUAGE SQL SET search_path = 'pg_catalog, pg_temp';
+


### PR DESCRIPTION
When using SET search_path the schemas must not be enclosed in single quotes
as otherwise the list of schemas will be treated as a single schema name instead.

Erroneous example:

```
SET search_path TO 'pg_catalog, temp';
```

Setting the search_path this way will result in the actual search_path being
pg_temp, pg_catalog, "pg_catalog, pg_temp" instead of the intended value of
pg_catalog, pg_temp. This would allow shadowing catalog relations with relations
in the pg_temp schema.
