### PR TITLE
Ignore CREATE OR REPLACE for functions when checking timescaledb code

### DIFF
--- a/.github/workflows/timescaledb.yml
+++ b/.github/workflows/timescaledb.yml
@@ -2,6 +2,9 @@ name: TimescaleDB
 on:
   schedule:
     - cron: '0 22 * * *'
+  pull_request:
+    paths: .github/workflows/timescaledb.yml
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,6 +46,7 @@ jobs:
     - name: Run pgspot
       run: |
         pgspot \
+          --ignore PS002 \
           --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts timestamp,"offset" interval)' \
           --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts timestamptz,"offset" interval)' \
           --proc-without-search-path 'extschema.time_bucket(bucket_width interval,ts date,"offset" interval)' \
@@ -51,7 +55,7 @@ jobs:
           --proc-without-search-path '_timescaledb_internal.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean)' \
           --proc-without-search-path '_timescaledb_internal.cagg_migrate_execute_plan(_cagg_data _timescaledb_catalog.continuous_agg)' \
           --proc-without-search-path '_timescaledb_functions.policy_compression(job_id integer,config jsonb)' \
-          --proc-without-search-path '_timescaledb_functions.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean,use_creation_time boolean,useam boolean)' \
+          --proc-without-search-path '_timescaledb_functions.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean,reindex_enabled boolean,use_creation_time boolean)' \
           --proc-without-search-path '_timescaledb_functions.cagg_migrate_execute_plan(_cagg_data _timescaledb_catalog.continuous_agg)' \
           --proc-without-search-path 'extschema.cagg_migrate(cagg regclass,override boolean,drop_old boolean)' \
         timescaledb/build/sql/timescaledb--*.sql


### PR DESCRIPTION
CREATE OR REPLACE was fixed by pg upstream to be a problem when
used in an extension context.
