### PR TITLE
Fix function SET search_path leaking into file-level state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## Unreleased
+
+- Fix `SET search_path` in a `CREATE`/`ALTER FUNCTION` clause leaking into file-level state and masking later warnings (incl. inside DO blocks)
+
 ## 0.9.2 (2026-03-03)
 
 - Add check for RAISE options

--- a/src/pgspot/visitors.py
+++ b/src/pgspot/visitors.py
@@ -359,10 +359,23 @@ class SQLVisitor(Visitor):
                         self.state.error("PS007", format_name(node.defnames))
 
     def visit_VariableSetStmt(self, ancestors, node):
+        # A `SET search_path` that is part of a function's options (a
+        # `CREATE`/`ALTER FUNCTION ... SET search_path = ...` clause) only
+        # applies while that function runs. The function body is analyzed
+        # separately with its own search_path state, so it must not update the
+        # file-level state, which would wrongly mark the statements following
+        # the function as having a secure search_path. The clause is still
+        # linted for other issues (e.g. PS018).
+        in_function_options = (
+            ancestors.find_nearest((ast.CreateFunctionStmt, ast.AlterFunctionStmt))
+            is not None
+        )
+
         # only search_path relevant
         if node.name == "search_path":
             if node.kind == VariableSetKind.VAR_SET_VALUE:
-                self.state.set_searchpath(node, node.is_local)
+                if not in_function_options:
+                    self.state.set_searchpath(node, node.is_local)
 
                 # check misquoted search_path
                 # When we detect a , in a schema name we assume this is due to misquoting
@@ -370,7 +383,8 @@ class SQLVisitor(Visitor):
                     self.state.error("PS018", "")
 
             if node.kind == VariableSetKind.VAR_RESET:
-                self.state.reset_searchpath()
+                if not in_function_options:
+                    self.state.reset_searchpath()
 
     def visit_CaseExpr(self, ancestors, node):
         if node.arg and not self.state.searchpath_secure:

--- a/tests/function_set_search_path_leak_test.py
+++ b/tests/function_set_search_path_leak_test.py
@@ -1,0 +1,57 @@
+from util import run
+
+
+# A function's `SET search_path` only applies while that function executes; it
+# must not mark the rest of the script as having a secure search_path.
+def test_function_set_search_path_does_not_leak_to_later_statement():
+    sql = """
+    CREATE FUNCTION f() RETURNS int LANGUAGE sql
+        SET search_path = pg_catalog, pg_temp
+    AS $$ SELECT 1 $$;
+    SELECT unsafe_call();
+    """
+    output = run(sql)
+
+    assert "PS016" in output
+
+
+# An anonymous DO block runs under the session search_path, not under any
+# preceding function's `SET search_path`, so unqualified references inside it
+# must still be flagged.
+def test_function_set_search_path_does_not_leak_into_do_block():
+    sql = """
+    CREATE FUNCTION f() RETURNS int LANGUAGE sql
+        SET search_path = pg_catalog, pg_temp
+    AS $$ SELECT 1 $$;
+    DO $$ BEGIN PERFORM unsafe_do_call(); END $$;
+    """
+    output = run(sql)
+
+    assert "PS016" in output
+
+
+# `ALTER FUNCTION ... SET search_path` likewise only affects that function, so
+# it must not mark later statements as secure either.
+def test_alter_function_set_search_path_does_not_leak_to_later_statement():
+    sql = """
+    CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;
+    ALTER FUNCTION f() SET search_path = pg_catalog, pg_temp;
+    SELECT unsafe_after_alter();
+    """
+    output = run(sql)
+
+    assert "PS016" in output
+
+
+# `ALTER FUNCTION ... RESET search_path` only affects that function, so it must
+# not reset the file-level secure state established by a real top-level SET.
+def test_function_reset_search_path_does_not_leak_to_later_statement():
+    sql = """
+    SET search_path = pg_catalog, pg_temp;
+    CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;
+    ALTER FUNCTION f() RESET search_path;
+    SELECT now();
+    """
+    output = run(sql)
+
+    assert "PS016" not in output


### PR DESCRIPTION
Fixes #253.

A `SET search_path` clause on a `CREATE`/`ALTER FUNCTION` only applies while that function runs, but pglast's auto-traversal visited the clause and updated pgspot's file-level search_path state — masking PS016/PS005/etc. warnings on every later statement (including inside DO blocks).

**Fix:** in `visit_VariableSetStmt`, skip the file-level `set_searchpath`/`reset_searchpath` mutation when the SET is nested in a function's options (`CreateFunctionStmt`/`AlterFunctionStmt`), while still running the PS018 misquote check.

Adds regression tests for the CREATE/ALTER FUNCTION SET and RESET cases and the DO-block case.